### PR TITLE
Default: 2. User 도메인 생성 및 조회 서비스 구현

### DIFF
--- a/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/User.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/User.java
@@ -1,0 +1,12 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import java.time.LocalDateTime;
+
+public record User(
+    Long id,
+    String name,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserErrorCode.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserErrorCode.java
@@ -1,0 +1,31 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+  INVALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID입니다."),
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public String getCode() {
+    return name();
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryService.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryService.java
@@ -1,0 +1,17 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import com.hhplus.tdd.clean.architecture.domain.user.dto.UserQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+  private final UserRepository userRepository;
+
+  public User getUserById(UserQuery.GetUserById query) {
+    return userRepository.getUserById(query.userId());
+  }
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserRepository.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+public interface UserRepository {
+
+  User getUserById(Long userId);
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/dto/UserQuery.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/domain/user/dto/UserQuery.java
@@ -1,0 +1,18 @@
+package com.hhplus.tdd.clean.architecture.domain.user.dto;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.BusinessException;
+import com.hhplus.tdd.clean.architecture.domain.user.UserErrorCode;
+
+public class UserQuery {
+
+  public record GetUserById(Long userId) {
+
+    public GetUserById {
+      if (userId == null || userId <= 0) {
+        throw new BusinessException(UserErrorCode.INVALID_USER_ID);
+      }
+    }
+
+  }
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserEntity.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserEntity.java
@@ -1,0 +1,47 @@
+package com.hhplus.tdd.clean.architecture.infrastructure.db.user;
+
+import com.hhplus.tdd.clean.architecture.domain.user.User;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "\"user\"")
+@Getter
+@NoArgsConstructor
+public class UserEntity extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String password;
+
+  public User toUser() {
+    return new User(id, name, getCreatedAt(), getUpdatedAt());
+  }
+
+  public UserEntity(Long id, String name, String password, LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+    super(createdAt, updatedAt);
+    this.id = id;
+    this.name = name;
+    this.password = password;
+  }
+
+  public UserEntity(Long id, String name, String password) {
+    this(id, name, password, null, null);
+  }
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserJpaRepository.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserJpaRepository.java
@@ -1,0 +1,7 @@
+package com.hhplus.tdd.clean.architecture.infrastructure.db.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+
+}

--- a/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/impl/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.hhplus.tdd.clean.architecture.infrastructure.db.user.impl;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.BusinessException;
+import com.hhplus.tdd.clean.architecture.domain.user.User;
+import com.hhplus.tdd.clean.architecture.domain.user.UserErrorCode;
+import com.hhplus.tdd.clean.architecture.domain.user.UserRepository;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserEntity;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+  private final UserJpaRepository userJpaRepository;
+
+  @Override
+  public User getUserById(Long userId) {
+    return userJpaRepository.findById(userId)
+        .map(UserEntity::toUser)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryServiceIntegrationTest.java
+++ b/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryServiceIntegrationTest.java
@@ -1,0 +1,66 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.BusinessException;
+import com.hhplus.tdd.clean.architecture.domain.user.dto.UserQuery;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserEntity;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserJpaRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("UserQueryService 통합 테스트")
+@Transactional
+class UserQueryServiceIntegrationTest {
+
+  @Autowired
+  private UserQueryService target;
+
+  @Autowired
+  private UserJpaRepository userJpaRepository;
+
+  @BeforeEach
+  void setUp() {
+    userJpaRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("getUserById 테스트 실패 - 존재하지 않는 사용자")
+  void shouldThrowExceptionWhenUserNotFound() {
+    // given
+    final Long userId = 1L;
+    final UserQuery.GetUserById query = new UserQuery.GetUserById(userId);
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.getUserById(query));
+
+    // then
+    assertThat(result.getMessage()).isEqualTo(UserErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("getUserById 테스트 성공")
+  void shouldSuccessfullyGetUserById() {
+    // given
+    final UserEntity userEntity = userJpaRepository.save(
+        new UserEntity(null, "test", "password", null, null));
+    final UserQuery.GetUserById query = new UserQuery.GetUserById(userEntity.getId());
+
+    // when
+    final User result = target.getUserById(query);
+
+    // then
+    assertThat(result.id()).isEqualTo(userEntity.getId());
+    assertThat(result.name()).isEqualTo(userEntity.getName());
+    assertThat(result.createdAt()).isNotNull();
+    assertThat(result.updatedAt()).isNull();
+  }
+
+}

--- a/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryServiceTest.java
+++ b/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserQueryServiceTest.java
@@ -1,0 +1,44 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import com.hhplus.tdd.clean.architecture.domain.user.dto.UserQuery;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserQueryService 단위 테스트")
+class UserQueryServiceTest {
+
+  @InjectMocks
+  private UserQueryService target;
+
+  @Mock
+  private UserRepository userRepository;
+
+
+  @Test
+  @DisplayName("getUserById 테스트")
+  void shouldSuccessfullyGetUserById() {
+    // given
+    final Long userId = 1L;
+    final User user = new User(userId, "test", LocalDateTime.now(), LocalDateTime.now());
+    final UserQuery.GetUserById query = new UserQuery.GetUserById(userId);
+    doReturn(user).when(userRepository).getUserById(userId);
+
+    // when
+    final User result = target.getUserById(query);
+
+    // then
+    assertThat(result.id()).isEqualTo(user.id());
+    assertThat(result.name()).isEqualTo(user.name());
+    assertThat(result.createdAt()).isEqualTo(user.createdAt());
+    assertThat(result.updatedAt()).isEqualTo(user.updatedAt());
+  }
+}

--- a/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/UserRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.hhplus.tdd.clean.architecture.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.BusinessException;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserEntity;
+import com.hhplus.tdd.clean.architecture.infrastructure.db.user.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("UserRepository 통합 테스트")
+class UserRepositoryTest {
+
+  @Autowired
+  private UserRepository target;
+
+  @Autowired
+  private UserJpaRepository userJpaRepository;
+
+  @BeforeEach
+  void setUp() {
+    userJpaRepository.deleteAll();
+  }
+
+
+  @Test
+  @DisplayName("getUserById 테스트 실패 - 존재하지 않는 사용자")
+  void shouldThrowExceptionWhenUserNotFound() {
+    // given
+    final Long userId = 1L;
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.getUserById(userId));
+
+    // then
+    assertThat(result.getMessage()).isEqualTo(UserErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("getUserById 테스트 성공")
+  void shouldSuccessfullyGetUserById() {
+    // given
+    final UserEntity userEntity = userJpaRepository.save(
+        new UserEntity(null, "test", "password", null, null));
+
+    // when
+    final User result = target.getUserById(userEntity.getId());
+
+    // then
+    assertThat(result.id()).isEqualTo(userEntity.getId());
+    assertThat(result.name()).isEqualTo(userEntity.getName());
+    assertThat(result.createdAt()).isNotNull();
+    assertThat(result.updatedAt()).isNull();
+  }
+
+}

--- a/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/dto/UserQueryTest.java
+++ b/src/test/java/com/hhplus/tdd/clean/architecture/domain/user/dto/UserQueryTest.java
@@ -1,0 +1,76 @@
+package com.hhplus.tdd.clean.architecture.domain.user.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hhplus.tdd.clean.architecture.domain.common.error.BusinessException;
+import com.hhplus.tdd.clean.architecture.domain.user.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserQuery 단위 테스트")
+class UserQueryTest {
+
+  @Nested
+  @DisplayName("GetUserById 테스트")
+  class GetUserByIdTest {
+
+    @Test
+    @DisplayName("생성자 테스트 실패 - userId가 null인 경우")
+    void shouldThrowExceptionWhenUserIdIsNull() {
+      // given
+      Long userId = null;
+
+      // when
+      BusinessException result = assertThrows(BusinessException.class,
+          () -> new UserQuery.GetUserById(userId));
+
+      // then
+      assertThat(result.getMessage()).isEqualTo(UserErrorCode.INVALID_USER_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성자 테스트 실패 - userId가 0인 경우")
+    void shouldThrowExceptionWhenUserIdIsZero() {
+      // given
+      Long userId = 0L;
+
+      // when
+      BusinessException result = assertThrows(BusinessException.class,
+          () -> new UserQuery.GetUserById(userId));
+
+      // then
+      assertThat(result.getMessage()).isEqualTo(UserErrorCode.INVALID_USER_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성자 테스트 실패 - userId가 음수인 경우")
+    void shouldThrowExceptionWhenUserIdIsNegative() {
+      // given
+      Long userId = -1L;
+
+      // when
+      BusinessException result = assertThrows(BusinessException.class,
+          () -> new UserQuery.GetUserById(userId));
+
+      // then
+      assertThat(result.getMessage()).isEqualTo(UserErrorCode.INVALID_USER_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성자 테스트 성공")
+    void shouldSuccessfullyCreateGetUserById() {
+      // given
+      Long userId = 1L;
+
+      // when
+      UserQuery.GetUserById result = new UserQuery.GetUserById(userId);
+
+      // then
+      assertThat(result.userId()).isEqualTo(userId);
+    }
+
+  }
+
+}

--- a/src/test/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserEntityTest.java
+++ b/src/test/java/com/hhplus/tdd/clean/architecture/infrastructure/db/user/UserEntityTest.java
@@ -1,0 +1,32 @@
+package com.hhplus.tdd.clean.architecture.infrastructure.db.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hhplus.tdd.clean.architecture.domain.user.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserEntity 단위 테스트")
+class UserEntityTest {
+
+  @Test
+  @DisplayName("toUser 테스트")
+  void shouldSuccessfullyConvertToUser() {
+    // given
+    final Long id = 1L;
+    final String name = "test";
+    final String password = "password";
+    final UserEntity userEntity = new UserEntity(id, name, password, LocalDateTime.now(), null);
+
+    // when
+    final User user = userEntity.toUser();
+
+    // then
+    assertThat(user.id()).isEqualTo(userEntity.getId());
+    assertThat(user.name()).isEqualTo(userEntity.getName());
+    assertThat(user.createdAt()).isEqualTo(userEntity.getCreatedAt());
+    assertThat(user.updatedAt()).isEqualTo(userEntity.getUpdatedAt());
+  }
+
+}


### PR DESCRIPTION
# 변경 사항
- User 도메인 및 entity 구현
- UserQueryService getUserById 구현 및 테스트 작성

# 리뷰 포인트
- 리뷰어님들이 생각했을 때 더 좋은 패턴이 보일 경우 공유해주시면 좋을 것 같습니다.
- 테스트 코드의 추가로 있으면 좋을 부분 또는 불 필요해 보이는 부분도 확인 부탁드립니다.
- User 도메인의 경우 Lecture(특강) 도메인에서 사용할 예정이라 미리 작업을 했습니다.
해당 도메인의 경우 Lecture(특강) 도메인 외에선 사용을 안할 것 같아서 Facade 및 Conroller를 구현하지 않았습니다.
실무에서도 이러한 Case가 발생한다면 서비스 계층까지만 구현하는 형태로 가는 걸까요?

ps. 실수로 base 브랜치를 안바꿨습니다. PR diff에는 이상 없으니 참고만해주세요. main 형상은 다시 맞췄습니다.